### PR TITLE
Block spam messages on bug reports

### DIFF
--- a/.settings/com.google.appengine.eclipse.core.prefs
+++ b/.settings/com.google.appengine.eclipse.core.prefs
@@ -1,5 +1,5 @@
 eclipse.preferences.version=1
-filesCopiedToWebInfLib=appengine-api-1.0-sdk-1.8.1.1.jar|appengine-api-labs.jar|appengine-endpoints.jar|appengine-jsr107cache-1.8.1.1.jar|jsr107cache-1.1.jar
+filesCopiedToWebInfLib=appengine-api-1.0-sdk-1.9.1.jar|appengine-api-labs.jar|appengine-endpoints-deps.jar|appengine-endpoints.jar|appengine-jsr107cache-1.9.1.jar|jsr107cache-1.1.jar
 gaeDatanucleusEnabled=false
 gaeDeployDialogSettings=
 gaeHrdEnabled=true

--- a/src/main/edu/iastate/music/marching/attendance/servlets/ErrorServlet.java
+++ b/src/main/edu/iastate/music/marching/attendance/servlets/ErrorServlet.java
@@ -30,8 +30,14 @@ public class ErrorServlet extends AbstractBaseServlet {
 	public static void showError(HttpServletRequest req,
 			HttpServletResponse resp, int i) throws ServletException,
 			IOException {
-		new PageBuilder(Page.index, SERVLET_PATH).setPageTitle(
-				new Integer(i).toString() + " Error").passOffToJsp(req, resp);
+
+		showError(req, resp, new Integer(i).toString() + " Error");
+	}
+
+	public static void showError(HttpServletRequest req,
+			HttpServletResponse resp, String message) throws ServletException,
+			IOException {
+		new PageBuilder(Page.index, SERVLET_PATH).setPageTitle(message).passOffToJsp(req, resp);
 	}
 
 	@Override

--- a/src/main/edu/iastate/music/marching/attendance/servlets/PublicServlet.java
+++ b/src/main/edu/iastate/music/marching/attendance/servlets/PublicServlet.java
@@ -6,6 +6,7 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import edu.iastate.music.marching.attendance.App;
 import edu.iastate.music.marching.attendance.beans.PageTemplateBean;
 import edu.iastate.music.marching.attendance.model.interact.DataTrain;
 import edu.iastate.music.marching.attendance.model.store.User;
@@ -79,7 +80,14 @@ public class PublicServlet extends AbstractBaseServlet {
 		String error_messages = req.getParameter("error_messages");
 		String field_values = req.getParameter("FieldValues");
 		String success_message = req.getParameter("success_message");
+		String spam_catcher = req.getParameter("leave_empty_spamcatcher");
 		boolean mobileSite = PageTemplateBean.onMobileSite(req.getSession());
+
+		// This field is hidden in the bug report form, no human should have entered text
+		if(spam_catcher != "") {
+			ErrorServlet.showError(req, resp, "Bug reporting failed, please send an email directly to: " + App.Emails.BUGREPORT_EMAIL_TO);
+			return;
+		}
 
 		if (error_messages != null && !error_messages.equals("[]")) {
 			description = "\nError Messages: " + error_messages + "\n"

--- a/war/WEB-INF/common/bugreport.jsp
+++ b/war/WEB-INF/common/bugreport.jsp
@@ -25,5 +25,6 @@
 	<input type="hidden" name="FieldValues" value="{}" />
 	<input type="hidden" name="error_messages" value="${error_messages}" />
 	<input type="hidden" name="success_message" value="${success_message}" />
+	<input type="hidden" name="leave_empty_spamcatcher" value="" />
 	<input type="submit" value="Submit" name="Submit" />
 </form>


### PR DESCRIPTION
I'm getting annoyed at all the spam messages coming through the bug report system.

Luckily, most spammers are quite stupid and won't be able to resist filling out the new hidden field "leave_empty_spamcatcher" in the bug report form. Boy will they regret it though, because doing so will make the bug submission fail and save us from their offers for cheap hotels and drugs.

Local tested and dev approved. (Tested locally and deployed to dev environment to verify behaviour)

P.S. From the reports it appears spammers use IE6 on Windows XP, they should upgrade their systems!
