### PR TITLE
Maven jre/appengine version updates

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -6,7 +6,7 @@
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="src" output="target/attendance-2.0.1-gamma/WEB-INF/classes" path="src/main/java">
+	<classpathentry kind="src" output="src/main/webapp/WEB-INF/classes" path="src/main/java">
 		<attributes>
 			<attribute name="optional" value="true"/>
 			<attribute name="maven.pomderived" value="true"/>
@@ -24,7 +24,7 @@
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.6">
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER">
 		<attributes>
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
     <maven.compiler.target>1.6</maven.compiler.target>
 
     <!-- GAE properties -->
-    <gae.version>1.6.6</gae.version>
+    <gae.version>1.9.6</gae.version>
     <gae.home>${user.home}/.m2/repository/com/google/appengine/appengine-java-sdk/${gae.version}/appengine-java-sdk-${gae.version}</gae.home>
     <gae.application.version>1</gae.application.version>
 


### PR DESCRIPTION
- Remove bogus constraint restricting JRE container to 1.6
- Retarget class output folder according to eclipse's suggestion, removes explict version name from the path
- Latest GAE version is 1.9.6
