### PR TITLE
Reduce datastore requests to prepare /director/attendance

### DIFF
--- a/src/main/java/edu/iastate/music/marching/attendance/servlets/DirectorServlet.java
+++ b/src/main/java/edu/iastate/music/marching/attendance/servlets/DirectorServlet.java
@@ -769,11 +769,14 @@ public class DirectorServlet extends AbstractBaseServlet {
 		List<User> students = train.users().get(User.Type.Student);
 		Map<User, List<Absence>> absenceList = new HashMap<User, List<Absence>>();
 
-		for (User s : students) {
-			// TODO may be more efficient to just get them all and then split
-			// here
-			List<Absence> a = train.absences().get(s);
-			absenceList.put(s, a);
+		for(Absence a : train.absences().getAll())
+		{
+			if (!absenceList.containsKey(a.getStudent()))
+			{
+				absenceList.put(a.getStudent(), new ArrayList<Absence>());
+			}
+			
+			absenceList.get(a.getStudent()).add(a);
 		}
 
 		page.setAttribute("students", students);


### PR DESCRIPTION
Results in a 2x improvement bringing page generation time down from 8s to 4s

Based on data from the app-stats plugin part of the reason /director/attendance was so slow was the huge number of "datastore_v3.RunQuery" calls to look up the list of absences for each user. If we instead follow the advice of an old, wise TODO we can get all abscense in a single batch query and then sort them out by user.
