### PR TITLE
Enable appstats to track datastore usage

### DIFF
--- a/src/main/webapp/WEB-INF/app.yaml
+++ b/src/main/webapp/WEB-INF/app.yaml
@@ -19,6 +19,31 @@ web_xml: |
     <extension>appcache</extension> 
     <mime-type>text/cache-manifest</mime-type> 
   </mime-mapping> 
+  <filter>
+    <filter-name>appstats</filter-name>
+     <filter-class>com.google.appengine.tools.appstats.AppstatsFilter</filter-class>
+  </filter>
+  <filter-mapping>
+    <filter-name>appstats</filter-name>
+    <url-pattern>/*</url-pattern>
+  </filter-mapping>
+  <servlet>
+    <servlet-name>appstats</servlet-name>
+    <servlet-class>com.google.appengine.tools.appstats.AppstatsServlet</servlet-class>
+  </servlet>
+  <servlet-mapping>
+    <servlet-name>appstats</servlet-name>
+    <url-pattern>/appstats/*</url-pattern>
+  </servlet-mapping>
+  <security-constraint>
+    <web-resource-collection>
+      <web-resource-name>appstats</web-resource-name>
+      <url-pattern>/appstats/*</url-pattern>
+    </web-resource-collection>
+    <auth-constraint>
+      <role-name>admin</role-name>
+    </auth-constraint>
+  </security-constraint>
   
 sessions_enabled: true
 

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -158,4 +158,29 @@
   <extension>appcache</extension> 
   <mime-type>text/cache-manifest</mime-type> 
 </mime-mapping> 
+<filter>
+  <filter-name>appstats</filter-name>
+   <filter-class>com.google.appengine.tools.appstats.AppstatsFilter</filter-class>
+</filter>
+<filter-mapping>
+  <filter-name>appstats</filter-name>
+  <url-pattern>/*</url-pattern>
+</filter-mapping>
+<servlet>
+  <servlet-name>appstats</servlet-name>
+  <servlet-class>com.google.appengine.tools.appstats.AppstatsServlet</servlet-class>
+</servlet>
+<servlet-mapping>
+  <servlet-name>appstats</servlet-name>
+  <url-pattern>/appstats/*</url-pattern>
+</servlet-mapping>
+<security-constraint>
+  <web-resource-collection>
+    <web-resource-name>appstats</web-resource-name>
+    <url-pattern>/appstats/*</url-pattern>
+  </web-resource-collection>
+  <auth-constraint>
+    <role-name>admin</role-name>
+  </auth-constraint>
+</security-constraint>
 </web-app>


### PR DESCRIPTION
Enables looking at the datastore usage per-request to identify bottlenecks and ways we can improve performance.
