### PR TITLE
Force HTTPS for the entire site

### DIFF
--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -183,4 +183,14 @@
     <role-name>admin</role-name>
   </auth-constraint>
 </security-constraint>
+  <!-- Force all url's to be https -->
+  <security-constraint>
+    <web-resource-collection>
+      <web-resource-name>all</web-resource-name>
+      <url-pattern>/*</url-pattern>
+    </web-resource-collection>
+    <user-data-constraint>
+      <transport-guarantee>CONFIDENTIAL</transport-guarantee>
+    </user-data-constraint>
+  </security-constraint>
 </web-app>


### PR DESCRIPTION
- We already support HTTPS
- The data on the site includes protected information like grades
- We only use the *.appengine.com site url currently
- Leaves no reason not to be using HTTPS everywhere
