### PR TITLE
Fix #258 by updated the field app to use "/field/data" for requests

### DIFF
--- a/src/main/webapp/field/field.appcache
+++ b/src/main/webapp/field/field.appcache
@@ -1,11 +1,10 @@
 CACHE MANIFEST
 
 # Attendance Appcache
-# 8-18-14 v3.0.2
+# Last Updated: 25.8.2014
 
 NETWORK:
-/field/data/classlist
-/field/data/upload
+/field/data
 
 CACHE:
 index.html

--- a/src/main/webapp/field/index.html
+++ b/src/main/webapp/field/index.html
@@ -109,7 +109,7 @@
                 $("#classList").text("Updating...");
                 $("#update").hide(1000);
                 
-                $.get("/field/data/classlist", function(result, errorString) {
+                $.get("/field/data", function(result, errorString) {
                 	
                 	if(errorString != "success")
              	    {
@@ -237,7 +237,7 @@
 				
 				// Post the built string of information to the server
 				// Expects to get a result json string back from server
-				$.post("/field/data/upload", str, function(result, errorString){
+				$.post("/field/data", str, function(result, errorString){
              	    if(errorString != "success")
              	    {
              	    	// Data did not even get to the server


### PR DESCRIPTION
- 32d99ec introduced explicitly named pages to MobileAppDataServlet,
  breaking the behavior of endpoint /field/data/classlist and
  /field/data/upload
- Use /field/data as the endpoint in both cases, as it is supported by
  the index page of the new MobileAppDataServlet
- Update appcache appropriately
